### PR TITLE
🧑‍🤝‍🧑 Group `boto` packages in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      boto:
+        patterns:
+          - "boto*"


### PR DESCRIPTION
This pull request:

- Groups `boto*`, so `boto3` and `botocore` because they are dependant on each other

Note: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 