### PR TITLE
Add distinct function for tagging objects that appends rather than overwrites tags

### DIFF
--- a/src/var/task/handler.py
+++ b/src/var/task/handler.py
@@ -150,7 +150,6 @@ def move_to_quarantine(object_key):
             object_key=object_key,
             scan_result="infected",
         )
-
         print("File moved to quarantine and tagged")
 
     except botocore.exceptions.ClientError as e:
@@ -163,7 +162,7 @@ def update_tags(
     scan_result: str,
 ) -> None:
     """Add tags for result of file scan to onject.
-    
+
     This will append two new tags on top of any existing object tags:
     * scan-time
     * scan
@@ -174,25 +173,24 @@ def update_tags(
     # Retrieve existing tags for the object.
     response = s3_client.get_object_tagging(
         Bucket=bucket_name,
-        Key=object_key
+        Key=object_key,
     )
-    tags = response.get('TagSet', [])
+    tags = response.get("TagSet", [])
 
     additional_tags = {
-        'scan-result': scan_result,
-        'scan-time': scan_time,
+        "scan-result": scan_result,
+        "scan-time": scan_time,
     }
 
     # Merge existing tags with additional tags.
-    tags.extend([
-        {'Key': key, 'Value': value}
-        for key, value in additional_tags.items()
-    ])
+    tags.extend(
+        [{"Key": key, "Value": value} for key, value in additional_tags.items()]
+    )
 
     s3_client.put_object_tagging(
         Bucket=bucket_name,
         Key=object_key,
-        Tagging={'TagSet': tags}
+        Tagging={"TagSet": tags},
     )
 
 

--- a/src/var/task/handler.py
+++ b/src/var/task/handler.py
@@ -165,7 +165,7 @@ def update_tags(
 
     This will append two new tags on top of any existing object tags:
     * scan-time
-    * scan
+    * scan-result
 
     Note, if any tags are present with the same name, this will not overwrite
     the tag with the same name, it will attempt to add the tag twice.


### PR DESCRIPTION
This function changes the tagging process so instead of only two tags being present on the object post scanning, any pre existing tags are retained and the scan result tags are appended.

Done this, as in my use case for this in Electronic Monitoring, the files I'm passing in to be scanned already have tags defining some metadata about the content of the files that I don't want to lose.