### PR TITLE
✨  Improved testing + local development tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: build debug test-definition-download test-scan test-definition-upload
+
+
+IMAGE_NAME ?= analytical-platform.service.justice.gov.uk/ingestion-scan
+IMAGE_TAG  ?= local
+
+build:
+	docker build --platform linux/amd64 --file Dockerfile --tag $(IMAGE_NAME):$(IMAGE_TAG) .
+
+debug: build
+	docker run -it --rm \
+		--platform linux/amd64 \
+		--hostname ingestion-scan \
+		--name analytical-platform-ingestion-scan \
+		--entrypoint /bin/bash \
+		$(IMAGE_NAME):$(IMAGE_TAG)
+
+test-definition-download: build
+	docker run --rm \
+		--platform linux/amd64 \
+		--name analytical-platform-ingestion-scan-test-download \
+		$(IMAGE_NAME):$(IMAGE_TAG) \
+		python test_definition_download.py
+
+test-scan: build
+	docker run --rm \
+		--platform linux/amd64 \
+		--name analytical-platform-ingestion-scan-test-scan \
+		$(IMAGE_NAME):$(IMAGE_TAG) \
+		python test_scan.py
+
+test-definition-upload: build
+	docker run --rm \
+		--platform linux/amd64 \
+		--name analytical-platform-ingestion-scan-test-upload \
+		$(IMAGE_NAME):$(IMAGE_TAG) \
+		python test_definition_upload.py
+

--- a/src/var/task/test_handler.py
+++ b/src/var/task/test_handler.py
@@ -1,0 +1,82 @@
+import os
+import subprocess
+
+
+def run_command(command):
+    result = subprocess.run(  # pylint: disable=subprocess-run-check
+        command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    return (
+        result.returncode,
+        result.stdout.decode("utf-8"),
+        result.stderr.decode("utf-8"),
+    )
+
+
+def test_definition_download():
+    # Create the directory to store the definitions
+    os.makedirs("/tmp/clamav/database", exist_ok=True)
+
+    # Pull the latest definitions
+    clamav_config = os.environ.get("LAMBDA_TASK_ROOT", "") + "/freshclam.conf"
+    exit_code, stdout, stderr = run_command(
+        f'freshclam --user root --config-file="{clamav_config}"'
+    )
+
+    if exit_code != 0:
+        print(f"Failed to download ClamAV definitions: {stderr}")
+        return
+
+    print("ClamAV Definitions downloaded successfully.")
+
+    # Create a test file with content "test"
+    test_file_path = os.path.join(os.getcwd(), "test.txt")
+    with open(test_file_path, 'w') as test_file:
+        test_file.write("test")
+
+    # Create a test file named "test space.txt"
+    test_space_file_path = os.path.join(os.getcwd(), "test space.txt")
+    with open(test_space_file_path, 'w') as test_space_file:
+        test_space_file.write("This file has a space in it's name.")
+
+    # Create an EICAR test file
+    eicar_file_path = os.path.join(os.getcwd(), "eicar.txt")
+    with open(eicar_file_path, 'w') as eicar_file:
+        eicar_file.write("X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*")
+
+    # Scan the test file using the downloaded definitions
+    exit_code, stdout, stderr = run_command(
+        f"clamscan --database=/tmp/clamav/database {test_file_path}"
+    )
+
+    if exit_code == 0:
+        print(f"Scan result for {test_file_path}: Clean")
+    else:
+        print(f"Scan result for {test_file_path}: Infected")
+        print(stderr)
+
+    # Scan the EICAR test file
+    exit_code, stdout, stderr = run_command(
+        f"clamscan --database=/tmp/clamav/database {eicar_file_path}"
+    )
+
+    if exit_code == 0:
+        print(f"Scan result for {eicar_file_path}: Clean")
+    else:
+        print(f"Scan result for {eicar_file_path}: Infected")
+        print(stderr)
+
+    # Scan the "test space.txt" file
+    exit_code, stdout, stderr = run_command(
+        f"clamscan --database=/tmp/clamav/database {test_space_file_path}"
+    )
+
+    if exit_code == 0:
+        print(f"Scan result for {test_space_file_path}: Clean")
+    else:
+        print(f"Scan result for {test_space_file_path}: Infected")
+        print(stderr)
+
+
+if __name__ == "__main__":
+    test_definition_download()


### PR DESCRIPTION
This is related to [this](https://github.com/ministryofjustice/analytical-platform/issues/5891) bug.


🚧  WIP 👷‍♂️ 🚧  WIP 👷‍♂️ 🚧  WIP 👷‍♂️ 🚧  WIP 👷‍♂️ 🚧  WIP 👷‍♂️ 

Currently the new `test_handler.py` function downloads the ClamAV definitions and scans test files which are created in the container upon running the python file. 

It returns:

```
ClamAV Definitions downloaded successfully.
Scan result for /var/task/test.txt: Clean
Scan result for /var/task/eicar.txt: Infected
Scan result for /var/task/test space.txt: Infected
/var/task/test: No such file or directory
WARNING: /var/task/test: Can't access file
space.txt: No such file or directory
WARNING: space.txt: Can't access file
```

I need to rectify this error to allow for testing in the event of a file with a space in the name. 

Edit 31st Oct. The approach here is wrong at the moment. Pivoting. 