### PR TITLE
:wrench: Update ClamAV -> `1.4.3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - AWS Lambda does not support HEALTHCHECK
 #checkov:skip=CKV_DOCKER_3: USER not required - A non-root user is used by AWS Lambda
-FROM public.ecr.aws/lambda/python:3.13@sha256:896f5b5410c9d6f2584d9230e5485793354c0c62b1984b98c7f2bcf1815412ce
+FROM public.ecr.aws/lambda/python:3.13@sha256:a0ca8c190db48ddbb341ce893f4a4ecf04b1adf9b696e0b26066c29211e4cdff
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -10,9 +10,8 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
 
 RUN microdnf update \
     && microdnf install --assumeyes \
-         clamav-0.103.12-1.amzn2023.0.1.x86_64 \
-         clamav-update-0.103.12-1.amzn2023.0.1.x86_64 \
-         clamd-0.103.12-1.amzn2023.0.1.x86_64 \
+         clamav1.4-1.4.3-1.amzn2023.0.1.x86_64\
+         clamd1.4-1.4.3-1.amzn2023.0.1.x86_64 \
          tar-2:1.34-1.amzn2023.0.4.x86_64 \
     && microdnf clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
 
 RUN microdnf update \
     && microdnf install --assumeyes \
-         clamav1.4-1.4.3-1.amzn2023.0.1.x86_64\
+         clamav1.4-1.4.3-1.amzn2023.0.1.x86_64 \
          clamd1.4-1.4.3-1.amzn2023.0.1.x86_64 \
          tar-2:1.34-1.amzn2023.0.4.x86_64 \
     && microdnf clean all

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker build --platform linux/amd64 --file Dockerfile --tag analytical-platform.
 ### Run
 
 ```bash
-docker run -it bash --rm \
+docker run -it --rm \
   --platform linux/amd64 \
   --hostname ingestion-scan \
   --name analytical-platform-ingestion-scan \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker build --platform linux/amd64 --file Dockerfile --tag analytical-platform.
 ### Run
 
 ```bash
-docker run -it --rm \
+docker run -it bash --rm \
   --platform linux/amd64 \
   --hostname ingestion-scan \
   --name analytical-platform-ingestion-scan \
@@ -56,7 +56,7 @@ docker run -it --rm --platform linux/amd64 --entrypoint /bin/bash public.ecr.aws
 
 microdnf update
 
-microdnf repoquery ${PACKAGE} # for example clamav, clamav-update or clamd
+microdnf repoquery ${PACKAGE} # for example clamav1.4, or clamd1.4
 ```
 
 ## Maintenance

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -5,12 +5,12 @@ commandTests:
   - name: "clamscan"
     command: "clamscan"
     args: ["--version"]
-    expectedOutput: ["ClamAV 0.103.12"]
+    expectedOutput: ["ClamAV 1.4.3"]
 
   - name: "freshclam"
     command: "freshclam"
     args: ["--version"]
-    expectedOutput: ["ClamAV 0.103.12"]
+    expectedOutput: ["ClamAV 1.4.3"]
 
   - name: "tar"
     command: "tar"


### PR DESCRIPTION
This PR updates ClamAV. The naming in the Amazon repository has changed which is why this wasn't caught via our normal processes.

Relates to https://github.com/Cisco-Talos/clamav/issues/1583