### PR TITLE
chore(apm): migrate from data-platform-ai-toolkit to ai-toolkit

### DIFF
--- a/.github/instructions/language.instructions.md
+++ b/.github/instructions/language.instructions.md
@@ -1,5 +1,6 @@
 ---
 description: Language instructions
+source: https://github.com/ministryofjustice/ai-toolkit/blob/main/toolkits/universal/.apm/instructions/language.instructions.md
 ---
 
 # Language

--- a/.github/instructions/ministryofjustice.instructions.md
+++ b/.github/instructions/ministryofjustice.instructions.md
@@ -1,9 +1,9 @@
 ---
 description: Ministry of Justice Standards
+source: https://github.com/ministryofjustice/ai-toolkit/blob/main/toolkits/universal/.apm/instructions/ministryofjustice.instructions.md
 ---
 
 # Ministry of Justice Standards
 
-- Adhere to guidance published under [ministryofjustice/.github](https://github.com/ministryofjustice/.github)
 - Follow security best practices for government services
 - Always use MOJ as the abbreviation for Ministry of Justice, not MoJ or moj

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,53 +1,53 @@
-lockfile_version: "1"
-generated_at: "2026-08-07T14:38:16.435101+00:00"
+lockfile_version: '1'
+generated_at: '2026-08-19T20:48:02.386766+00:00'
 apm_version: 0.28.0
 dependencies:
-  - repo_url: ministryofjustice/data-platform-ai-toolkit
-    name: universal
-    host: github.com
-    resolved_commit: 943ecee009ac2d9717811b90af2701e4134c1bcf
-    resolved_ref: main
-    version: 1.0.0
-    virtual_path: toolkits/universal
-    is_virtual: true
-    package_type: apm_package
-    deployed_files:
-      - .github/instructions/language.instructions.md
-      - .github/instructions/ministryofjustice.instructions.md
-    deployed_file_hashes:
-      .github/instructions/language.instructions.md: sha256:70e9d0f220f2ceec1cf5b8088c9e199259670f9baa383b330ff3ba9e4107e655
-      .github/instructions/ministryofjustice.instructions.md: sha256:470dc2fbec601f32b14b73f6665a17dd7e3427c0bcdc5c8197c5e3905d30dfcc
-    content_hash: sha256:d375ca1db8fc999bc92d31994eba9aa81611fb48d0750d557e4d27ab1249f68e
+- repo_url: ministryofjustice/ai-toolkit
+  name: universal
+  host: github.com
+  resolved_commit: 69e66f8ce36ead7125ab5d93840a8a16aa87d883
+  resolved_ref: main
+  version: 1.0.0
+  virtual_path: toolkits/universal
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .github/instructions/language.instructions.md
+  - .github/instructions/ministryofjustice.instructions.md
+  deployed_file_hashes:
+    .github/instructions/language.instructions.md: sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
+    .github/instructions/ministryofjustice.instructions.md: sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
+  content_hash: sha256:f503de05a01685575188eee0610cafd4ac2ed0688bf4848d16f5f5e0c41ab435
 deployments:
-  - kind: project-relative
-    target: copilot
-    value: .github/instructions/language.instructions.md
-    runtime: null
-    scope: project
-    owners:
-      - ministryofjustice/data-platform-ai-toolkit/toolkits/universal
-    active_owner: ministryofjustice/data-platform-ai-toolkit/toolkits/universal
-    content_hash: sha256:70e9d0f220f2ceec1cf5b8088c9e199259670f9baa383b330ff3ba9e4107e655
-  - kind: project-relative
-    target: copilot
-    value: .github/instructions/ministryofjustice.instructions.md
-    runtime: null
-    scope: project
-    owners:
-      - ministryofjustice/data-platform-ai-toolkit/toolkits/universal
-    active_owner: ministryofjustice/data-platform-ai-toolkit/toolkits/universal
-    content_hash: sha256:470dc2fbec601f32b14b73f6665a17dd7e3427c0bcdc5c8197c5e3905d30dfcc
-  - kind: uri
-    target: mcp
-    value: github
-    runtime: vscode
-    scope: project
-    owners:
-      - .
-    active_owner: .
-    content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .github/instructions/language.instructions.md
+  runtime: null
+  scope: project
+  owners:
+  - ministryofjustice/ai-toolkit/toolkits/universal
+  active_owner: ministryofjustice/ai-toolkit/toolkits/universal
+  content_hash: sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
+- kind: project-relative
+  target: copilot
+  value: .github/instructions/ministryofjustice.instructions.md
+  runtime: null
+  scope: project
+  owners:
+  - ministryofjustice/ai-toolkit/toolkits/universal
+  active_owner: ministryofjustice/ai-toolkit/toolkits/universal
+  content_hash: sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
+- kind: uri
+  target: mcp
+  value: github
+  runtime: vscode
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: null
 mcp_servers:
-  - github
+- github
 mcp_configs:
   github:
     name: github
@@ -56,6 +56,6 @@ mcp_configs:
     url: https://api.githubcopilot.com/mcp/
 mcp_target_servers:
   vscode:
-    - github
+  - github
 mcp_config_provenance:
   github: universal

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,62 +1,69 @@
 ---
 lockfile_version: '1'
-generated_at: '2026-08-19T20:48:02.386766+00:00'
+generated_at: '2026-08-19T20:48:05.105356+00:00'
 apm_version: 0.28.0
 dependencies:
   - repo_url: ministryofjustice/ai-toolkit
-  name: universal
-  host: github.com
-  resolved_commit: 69e66f8ce36ead7125ab5d93840a8a16aa87d883
-  resolved_ref: main
-  version: 1.0.0
-  virtual_path: toolkits/universal
-  is_virtual: true
-  package_type: apm_package
+    name: universal
+    host: github.com
+    resolved_commit: 69e66f8ce36ead7125ab5d93840a8a16aa87d883
+    resolved_ref: main
+    version: 1.0.0
+    virtual_path: toolkits/universal
+    is_virtual: true
+    package_type: apm_package
     deployed_files:
       - ".github/instructions/language.instructions.md"
       - ".github/instructions/ministryofjustice.instructions.md"
-  deployed_file_hashes:
-    ".github/instructions/language.instructions.md": sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
-    ".github/instructions/ministryofjustice.instructions.md": sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
-  content_hash: sha256:f503de05a01685575188eee0610cafd4ac2ed0688bf4848d16f5f5e0c41ab435
+    deployed_file_hashes:
+      ".github/instructions/language.instructions.md": sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
+      ".github/instructions/ministryofjustice.instructions.md": sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
+    content_hash: sha256:f503de05a01685575188eee0610cafd4ac2ed0688bf4848d16f5f5e0c41ab435
+
 deployments:
   - kind: project-relative
-  target: copilot
-  value: ".github/instructions/language.instructions.md"
-  runtime:
-  scope: project
-  owners:
-  - ministryofjustice/ai-toolkit/toolkits/universal
-  active_owner: ministryofjustice/ai-toolkit/toolkits/universal
-  content_hash: sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
+    target: copilot
+    value: ".github/instructions/language.instructions.md"
+    runtime:
+    scope: project
+    owners:
+      - ministryofjustice/ai-toolkit/toolkits/universal
+    active_owner: ministryofjustice/ai-toolkit/toolkits/universal
+    content_hash: sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
+
   - kind: project-relative
-  target: copilot
-  value: ".github/instructions/ministryofjustice.instructions.md"
-  runtime:
-  scope: project
-  owners:
-  - ministryofjustice/ai-toolkit/toolkits/universal
-  active_owner: ministryofjustice/ai-toolkit/toolkits/universal
-  content_hash: sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
+    target: copilot
+    value: ".github/instructions/ministryofjustice.instructions.md"
+    runtime:
+    scope: project
+    owners:
+      - ministryofjustice/ai-toolkit/toolkits/universal
+    active_owner: ministryofjustice/ai-toolkit/toolkits/universal
+    content_hash: sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
+
   - kind: uri
-  target: mcp
-  value: github
-  runtime: vscode
-  scope: project
-  owners:
-  - "."
-  active_owner: "."
-  content_hash:
+    target: mcp
+    value: github
+    runtime: vscode
+    scope: project
+    owners:
+      - "."
+    active_owner: "."
+    content_hash:
+
 mcp_servers:
   - github
+
 mcp_configs:
   github:
     name: github
     transport: http
     registry: false
     url: https://api.githubcopilot.com/mcp/
+
 mcp_target_servers:
   vscode:
     - github
+
 mcp_config_provenance:
   github: universal

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,8 +1,9 @@
+---
 lockfile_version: '1'
 generated_at: '2026-08-19T20:48:02.386766+00:00'
 apm_version: 0.28.0
 dependencies:
-- repo_url: ministryofjustice/ai-toolkit
+  - repo_url: ministryofjustice/ai-toolkit
   name: universal
   host: github.com
   resolved_commit: 69e66f8ce36ead7125ab5d93840a8a16aa87d883
@@ -11,43 +12,43 @@ dependencies:
   virtual_path: toolkits/universal
   is_virtual: true
   package_type: apm_package
-  deployed_files:
-  - .github/instructions/language.instructions.md
-  - .github/instructions/ministryofjustice.instructions.md
+    deployed_files:
+      - ".github/instructions/language.instructions.md"
+      - ".github/instructions/ministryofjustice.instructions.md"
   deployed_file_hashes:
-    .github/instructions/language.instructions.md: sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
-    .github/instructions/ministryofjustice.instructions.md: sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
+    ".github/instructions/language.instructions.md": sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
+    ".github/instructions/ministryofjustice.instructions.md": sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
   content_hash: sha256:f503de05a01685575188eee0610cafd4ac2ed0688bf4848d16f5f5e0c41ab435
 deployments:
-- kind: project-relative
+  - kind: project-relative
   target: copilot
-  value: .github/instructions/language.instructions.md
-  runtime: null
+  value: ".github/instructions/language.instructions.md"
+  runtime:
   scope: project
   owners:
   - ministryofjustice/ai-toolkit/toolkits/universal
   active_owner: ministryofjustice/ai-toolkit/toolkits/universal
   content_hash: sha256:dbbd7951e0cfcdff32b237f1b35ab62ce9f30ceb6c3674f8f1d028a2b7c7c9be
-- kind: project-relative
+  - kind: project-relative
   target: copilot
-  value: .github/instructions/ministryofjustice.instructions.md
-  runtime: null
+  value: ".github/instructions/ministryofjustice.instructions.md"
+  runtime:
   scope: project
   owners:
   - ministryofjustice/ai-toolkit/toolkits/universal
   active_owner: ministryofjustice/ai-toolkit/toolkits/universal
   content_hash: sha256:e5f98f5dae901db79b6a869826fb40fcc051fe1ddd057e5fd4dc8d7822e1e652
-- kind: uri
+  - kind: uri
   target: mcp
   value: github
   runtime: vscode
   scope: project
   owners:
-  - .
-  active_owner: .
-  content_hash: null
+  - "."
+  active_owner: "."
+  content_hash:
 mcp_servers:
-- github
+  - github
 mcp_configs:
   github:
     name: github
@@ -56,6 +57,6 @@ mcp_configs:
     url: https://api.githubcopilot.com/mcp/
 mcp_target_servers:
   vscode:
-  - github
+    - github
 mcp_config_provenance:
   github: universal

--- a/apm.yml
+++ b/apm.yml
@@ -5,4 +5,4 @@ targets:
   - copilot
 dependencies:
   apm:
-    - ministryofjustice/data-platform-ai-toolkit/toolkits/universal#main
+    - ministryofjustice/ai-toolkit/toolkits/universal#main


### PR DESCRIPTION
## Summary

Migrates the universal toolkit dependency from `ministryofjustice/data-platform-ai-toolkit` to `ministryofjustice/ai-toolkit` and regenerates the lockfile and deployed instructions.

## Changes

- [`apm.yml`](https://github.com/ministryofjustice/analytical-platform-ingestion-scan/blob/gary-h9-apm-migrate-ingestion-scan/apm.yml) — updated toolkit dependency from `ministryofjustice/data-platform-ai-toolkit/toolkits/universal#main` to `ministryofjustice/ai-toolkit/toolkits/universal#main`
- [`apm.lock.yaml`](https://github.com/ministryofjustice/analytical-platform-ingestion-scan/blob/gary-h9-apm-migrate-ingestion-scan/apm.lock.yaml) — regenerated to reference `ministryofjustice/ai-toolkit`
- [`.github/instructions/language.instructions.md`](https://github.com/ministryofjustice/analytical-platform-ingestion-scan/blob/gary-h9-apm-migrate-ingestion-scan/.github/instructions/language.instructions.md) — refreshed from the new toolkit source
- [`.github/instructions/ministryofjustice.instructions.md`](https://github.com/ministryofjustice/analytical-platform-ingestion-scan/blob/gary-h9-apm-migrate-ingestion-scan/.github/instructions/ministryofjustice.instructions.md) — refreshed from the new toolkit source